### PR TITLE
Add database creation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ brew services start mongodb/brew/mongodb-community
 sudo systemctl start mongod
 ```
 
+## Creating the Database and Collection
+
+To create the `search_engine` database and the `meta_data` collection in MongoDB, follow these steps:
+
+1. Open the MongoDB shell by running the following command in your terminal:
+
+```bash
+mongo
+```
+
+2. Create the `search_engine` database and switch to it:
+
+```javascript
+use search_engine
+```
+
+3. Create the `meta_data` collection:
+
+```javascript
+db.createCollection("meta_data")
+```
+
 ## Example Usage
 
 The web crawler starts from the base URL `https://github.com/schBenedikt` and extracts metadata from each page it visits. The metadata is then stored in the `meta_data` collection of the `search_engine` database in MongoDB.


### PR DESCRIPTION
Add instructions to create the database and collection in `README.md`.

* **Creating the Database and Collection**
  - Add a new section to the `README.md` to guide users on creating the `search_engine` database and the `meta_data` collection in MongoDB.
  - Provide a code snippet to create the database schema using the MongoDB shell.
  - Include steps to open the MongoDB shell, create the `search_engine` database, and create the `meta_data` collection.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/web-crawler/pull/5?shareId=a6ccd10f-310a-4ba5-878c-6461f0f6b6fd).