### PR TITLE
Add content storage to web crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # web-crawler
 
-A simple web crawler using Python that stores the metadata of each web page in a database.
+A simple web crawler using Python that stores the metadata and main content of each web page in a database.
 
 ## Purpose and Functionality
 
-The web crawler is designed to crawl web pages starting from a base URL, extract metadata such as title, description, image, locale, and type, and store this information in a MongoDB database. The crawler can handle multiple levels of depth and respects the `robots.txt` rules of the websites it visits.
+The web crawler is designed to crawl web pages starting from a base URL, extract metadata such as title, description, image, locale, type, and main content, and store this information in a MongoDB database. The crawler can handle multiple levels of depth and respects the `robots.txt` rules of the websites it visits.
 
 ## Dependencies
 
@@ -106,9 +106,9 @@ db.createCollection("meta_data")
 
 ## Example Usage
 
-The web crawler starts from the base URL `https://github.com/schBenedikt` and extracts metadata from each page it visits. The metadata is then stored in the `meta_data` collection of the `search_engine` database in MongoDB.
+The web crawler starts from the base URL `https://github.com/schBenedikt` and extracts metadata and main content from each page it visits. The metadata and main content are then stored in the `meta_data` collection of the `search_engine` database in MongoDB.
 
-Here is an example of how the metadata is stored in the database:
+Here is an example of how the metadata and main content are stored in the database:
 
 ```json
 {
@@ -117,11 +117,12 @@ Here is an example of how the metadata is stored in the database:
   "description": "GitHub profile of schBenedikt",
   "image": "https://avatars.githubusercontent.com/u/12345678?v=4",
   "locale": "en_US",
-  "type": "profile"
+  "type": "profile",
+  "main_content": "This is the main content of the page."
 }
 ```
 
-The web crawler will print the metadata of each page it visits to the console and save it to the database. If a page is not reachable, the corresponding entry will be deleted from the database.
+The web crawler will print the metadata and main content of each page it visits to the console and save it to the database. If a page is not reachable, the corresponding entry will be deleted from the database.
 
 ## Notes
 


### PR DESCRIPTION
Add functionality to store the main content of web pages in addition to metadata.

* **crawler.py**
  - Extract the main content or text of the web pages using BeautifulSoup.
  - Update the `save_meta_data_to_db` function to include the main content.
  - Print the main content of the web pages to the console.

* **README.md**
  - Update the description to mention storing the main content of the web pages.
  - Update the example usage to include the main content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SchBenedikt/web-crawler/pull/7?shareId=53dbfd8e-ca31-457f-a9de-b2c17ae0e53f).